### PR TITLE
Add Hat Try-On PRD for Team 7

### DIFF
--- a/teams/team_7/prd.md
+++ b/teams/team_7/prd.md
@@ -6,11 +6,11 @@
 
 ## Project Overview
 
-**Project Name:** _[Give your project a name]_
+**Project Name:** Hat Try-On
 
-**One-line Description:** _[What does it do in one sentence?]_
+**One-line Description:** Upload a photo of yourself and try on different hats to see how you look.
 
-**Type:** _[e.g., Chrome Extension, Web App, CLI Tool, etc.]_
+**Type:** Web App (React, Vite)
 
 ---
 
@@ -19,52 +19,39 @@
 ### Keep It Small!
 - Your MVP should be buildable in **10 minutes** by one person
 - Think "proof of concept" not "production ready"
-- If it sounds ambitious, make it simpler
-- **Use Cursor to help you plan this!** You need a project that has at least 5 features so everyone on your team can pick one and add it
-- Feel free to take one of the ideas below — this exercise is about learning the git flow, collaborating as a team, and understanding where Cursor's features fit into the SDLC
+- **Frontend only** — no server, no database, no auth, no external APIs
+- Photo stays in the browser (file input → preview). Hats are static images overlaid on the photo.
+- You need at least 5 features so everyone on your team can pick one and add it
 
-### Good Project Ideas
+### In Scope (Frontend-Only)
+- User selects a photo from their device (file input)
+- Photo is shown on screen; hat images are overlaid at a fixed position (e.g. top of photo)
+- Clicking or selecting a hat switches which hat is shown
+- All data in memory or localStorage only — no backend
 
-**Pong** — classic paddle-and-ball game
-- _Example features:_ scoreboard, sound effects, difficulty/speed settings
-
-**Memory Card Match** — flip cards to find matching pairs
-- _Example features:_ move counter, timer, win animation/confetti
-
-**Drawing Pad** — simple canvas you can sketch on
-- _Example features:_ color picker, brush size slider, eraser tool
-
-**Typing Speed Game** — type a passage and measure your words per minute
-- _Example features:_ WPM display, accuracy tracker, difficulty levels
-
-**Trivia Quiz** — multiple choice questions with score tracking
-- _Example features:_ timer per question, category selector, results summary screen
-
-### Bad Project Ideas (Too Big!)
-- Anything with a database -- tell cursor to avoid this
-- Anything requiring authentication
-- Anything with multiple pages/screens
-- Anything that "needs" an API
+### Out of Scope (Too Big for This Workshop)
+- No face detection or automatic hat placement (use a fixed or manually adjustable position)
+- No saving photos to a server or cloud
+- No user accounts or login
 
 ---
 
 ## Team Members & Tasks
 
-> **Important:** Each team member MUST have their own task. Tasks should be independent features that can be built in parallel without stepping on each other's toes.
+> **Important:** Each team member MUST have their own task. Tasks should be independent features that can be built in parallel.
 
 | Name | Task | Description |
 |------|------|-------------|
-| _[Name 1]_ | _[Feature 1]_ | _[Brief description]_ |
-| _[Name 2]_ | _[Feature 2]_ | _[Brief description]_ |
-| _[Name 3]_ | _[Feature 3]_ | _[Brief description]_ |
-| _[Name 4]_ | _[Feature 4]_ | _[Brief description]_ |
-| _[Name 5]_ | _[Feature 5]_ | _[Brief description]_ |
+| _[Name 1]_ | Hat gallery / more hats | Add a visible grid or list of all hats to choose from |
+| _[Name 2]_ | Hat position & size | Sliders or controls to move the hat and change its size |
+| _[Name 3]_ | Compare view | Side-by-side or before/after view (e.g. no hat vs selected hat) |
+| _[Name 4]_ | Favorites / "best look" | Mark one or more hats as favorites; show a simple favorites list (state only) |
+| _[Name 5]_ | Download result | Button to download the photo-with-hat as an image file (canvas export) |
 
 ### Task Guidelines
 - Each task should add something **visible** to the project
 - Tasks should be **independent** — no dependencies on other tasks
-- Think: new button, new section, new color scheme, new text, etc.
-- Everyone should be able to work at the same time without conflicts
+- One component or one clear area of the app per person to avoid merge conflicts
 
 ---
 
@@ -73,10 +60,15 @@
 > **One person** creates the foundation that everyone else builds on.
 
 **What the MVP includes:**
-- _[Describe the minimal working version]_
+- Single-page React app (Vite) with a file input to upload a photo
+- Display the selected photo (e.g. in an `<img>` or on a canvas)
+- A small set of hat images (e.g. from `public/hats/`) overlaid at a **fixed position** on the photo (e.g. top-center)
+- A way to switch the active hat (e.g. buttons or a dropdown) so the overlay updates
+- Minimal layout: upload area, photo + hat preview, and basic hat selector
 
 **What it does NOT include:**
-- _[List features deliberately left out for team members to add]_
+- No hat gallery UI — just enough to switch between 1–2 hats for the demo
+- No position/size controls, compare view, favorites, or download — those are feature slots
 
 ---
 
@@ -84,35 +76,36 @@
 
 > These are the features team members will add. Design them to be **independent** so people can work in parallel.
 
-### Feature 1: _[Name]_
+### Feature 1: Hat gallery / more hats
 - **Assigned to:** _[Team member]_
-- **Description:** _[What it does]_
-- **Files to modify/create:** _[Be specific]_
+- **Description:** Show all available hats in a grid or list. Clicking one sets it as the active hat. Uses existing hat assets in `public/hats/`.
+- **Files to modify/create:** e.g. `src/components/HatGallery.jsx`, and wire it into `App.jsx`
 
-### Feature 2: _[Name]_
+### Feature 2: Hat position & size
 - **Assigned to:** _[Team member]_
-- **Description:** _[What it does]_
-- **Files to modify/create:** _[Be specific]_
+- **Description:** Add sliders (or simple buttons) to move the hat up/down/left/right and to change its size so it fits different photos better.
+- **Files to modify/create:** e.g. `src/components/HatControls.jsx`, and use the values in the component that renders the hat overlay
 
-### Feature 3: _[Name]_
+### Feature 3: Compare view
 - **Assigned to:** _[Team member]_
-- **Description:** _[What it does]_
-- **Files to modify/create:** _[Be specific]_
+- **Description:** A way to see "no hat" vs "current hat" side by side (or a toggle), so users can compare how they look with and without a hat.
+- **Files to modify/create:** e.g. `src/components/CompareView.jsx`, and optional state in `App.jsx` for compare mode
 
-### Feature 4: _[Name]_
+### Feature 4: Favorites / "best look"
 - **Assigned to:** _[Team member]_
-- **Description:** _[What it does]_
-- **Files to modify/create:** _[Be specific]_
+- **Description:** Let the user mark the current hat as a favorite. Show a simple list or strip of favorited hats (state only; can use `useState` or `localStorage`). No backend.
+- **Files to modify/create:** e.g. `src/components/Favorites.jsx`, and state/callbacks in `App.jsx` if needed
 
-### Feature 5: _[Name]_
+### Feature 5: Download result
 - **Assigned to:** _[Team member]_
-- **Description:** _[What it does]_
-- **Files to modify/create:** _[Be specific]_
+- **Description:** A "Download" button that exports the current photo-with-hat as an image file (e.g. PNG) using the Canvas API, so the user can save or share it.
+- **Files to modify/create:** e.g. `src/components/DownloadButton.jsx` and a small helper that draws photo + hat to a canvas and triggers download; wire into `App.jsx`
 
 ---
 
 ## Success Criteria
 
-- [ ] MVP runs locally
-- [ ] Each team member has merged at least one PR
+- [ ] MVP runs locally (`npm run dev` in `hat-photo`)
+- [ ] User can upload a photo and see at least one hat overlaid
+- [ ] Each team member has merged at least one PR (one feature per person)
 - [ ] All features work together without breaking the app


### PR DESCRIPTION
Replaces the Team 7 PRD template with the Hat Try-On product spec: upload a photo, try on different hats (frontend-only, React/Vite). Includes base MVP scope and 5 parallel feature slots for the team.

Made with [Cursor](https://cursor.com)