### PR TITLE
feat(team_4): Add duration presets - closes #26

### DIFF
--- a/teams/team_4/base_mvp/index.html
+++ b/teams/team_4/base_mvp/index.html
@@ -79,6 +79,28 @@
       border-color: #4f46e5;
     }
     .pattern-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .duration-presets {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 2rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .preset-btn {
+      padding: 0.5rem 1rem;
+      font-size: 0.875rem;
+      border: 2px solid #c7d2fe;
+      border-radius: 8px;
+      background: white;
+      cursor: pointer;
+      color: #333;
+    }
+    .preset-btn[aria-pressed="true"] {
+      background: #4f46e5;
+      color: white;
+      border-color: #4f46e5;
+    }
+    .preset-btn:disabled { opacity: 0.5; cursor: not-allowed; }
     .controls { display: flex; gap: 1rem; }
     .cycle-counter {
       font-size: 1.25rem;
@@ -126,6 +148,11 @@
     <button class="pattern-btn" data-pattern="4-7-8" aria-pressed="false">4-7-8</button>
     <button class="pattern-btn" data-pattern="box" aria-pressed="false">Box</button>
   </div>
+  <div class="duration-presets" id="duration-presets">
+    <button class="preset-btn" data-seconds="30" aria-pressed="false">Quick (30 sec)</button>
+    <button class="preset-btn" data-seconds="60" aria-pressed="true">Standard (1 min)</button>
+    <button class="preset-btn" data-seconds="120" aria-pressed="false">Deep reset (2 min)</button>
+  </div>
   <p class="cue" id="cue">Click Start to begin</p>
   <div class="cycle-counter" id="cycle-counter" style="display: none;">
     Breath <span class="current" id="current-breath">1</span> of <span id="total-breaths-target">5</span>
@@ -142,6 +169,7 @@
     const startBtn = document.getElementById('start');
     const stopBtn = document.getElementById('stop');
     const patternBtns = document.querySelectorAll('.pattern-btn');
+    const presetBtns = document.querySelectorAll('.preset-btn');
 
     const PATTERNS = {
       '4-4-4': [
@@ -165,6 +193,7 @@
     let currentPattern = '4-4-4';
     let timeoutId = null;
     let isRunning = false;
+    let targetSeconds = 60;
     
     // Cycle counter state (Jesse's feature)
     let currentBreath = 1;
@@ -182,6 +211,8 @@
       patternBtns.forEach(btn => {
         btn.setAttribute('aria-pressed', btn.dataset.pattern === patternId);
       });
+      totalBreathsTarget = computeTargetCycles(targetSeconds);
+      if (totalBreathsTargetEl) totalBreathsTargetEl.textContent = totalBreathsTarget;
     }
 
     patternBtns.forEach(btn => {
@@ -190,6 +221,34 @@
         selectPattern(btn.dataset.pattern);
       });
     });
+
+    function getCycleDurationSeconds() {
+      const phases = PATTERNS[currentPattern];
+      return phases.reduce((sum, p) => sum + p.duration, 0);
+    }
+
+    function computeTargetCycles(seconds) {
+      const cycleSec = getCycleDurationSeconds();
+      return Math.max(1, Math.floor(seconds / cycleSec));
+    }
+
+    function selectPreset(seconds) {
+      targetSeconds = parseInt(seconds, 10);
+      totalBreathsTarget = computeTargetCycles(targetSeconds);
+      presetBtns.forEach(btn => {
+        btn.setAttribute('aria-pressed', parseInt(btn.dataset.seconds, 10) === targetSeconds);
+      });
+    }
+
+    presetBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (isRunning) return;
+        selectPreset(btn.dataset.seconds);
+        totalBreathsTargetEl.textContent = totalBreathsTarget;
+      });
+    });
+
+    totalBreathsTarget = computeTargetCycles(targetSeconds);
 
     function runPhase(phases, phaseIndex) {
       if (!isRunning) return;
@@ -244,6 +303,7 @@
       startBtn.disabled = false;
       stopBtn.disabled = true;
       patternBtns.forEach(btn => { btn.disabled = false; });
+      presetBtns.forEach(btn => { btn.disabled = false; });
       
       // Hide cycle counter but keep total visible (Jesse's feature)
       cycleCounterEl.style.display = 'none';


### PR DESCRIPTION
## Summary
Adds Quick (30 sec), Standard (1 min), and Deep reset (2 min) buttons to Calm Call. Selecting one sets how many breath cycles to run before auto-stopping.

Closes #26

## Changes
- Duration preset buttons: Quick (30 sec), Standard (1 min), Deep reset (2 min)
- Cycle count computed from preset duration + active breathing pattern
- Presets disabled while exercise is running

## Test plan
1. Open teams/team_4/base_mvp/index.html in a browser
2. Select Quick (30 sec), then Start — should complete ~2 cycles (4-4-4)
3. Select Deep reset (2 min), then Start — should complete ~10 cycles
4. Verify presets are disabled during exercise

Made with [Cursor](https://cursor.com)