### PR TITLE
Add SDLC deep-dive slides: discovery questions, pain points, solutions & video placeholders

### DIFF
--- a/workshop-slides/src/slides/SlideDeployDeepDive.jsx
+++ b/workshop-slides/src/slides/SlideDeployDeepDive.jsx
@@ -1,0 +1,95 @@
+const SlideDeployDeepDive = () => (
+  <>
+    <div className="phase-header">
+      <div className="phase-number deploy">06</div>
+      <h2>Deploy</h2>
+    </div>
+    <p className="small" style={{ marginBottom: '0.5rem' }}>
+      Getting code to production — and the infrastructure complexity that slows teams down
+    </p>
+
+    <div className="deepdive-cols">
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--red)' }}>Discovery Questions</h3>
+        <div className="pain-list">
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How often do you deploy? Daily, weekly, or less frequently? What gates the frequency?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How much DevOps / infrastructure work is handled by your engineers vs. a dedicated platform team?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"What does your deployment pipeline look like? How much of it is manual vs. automated?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How do you handle rollbacks, canary deploys, or feature flags?"</span>
+          </div>
+        </div>
+
+        <h3 style={{ color: 'var(--red)', marginTop: '0.75rem' }}>Common Pain Points</h3>
+        <div className="pain-list">
+          <div className="pain-item">
+            <span className="pain-icon">🏗️</span>
+            <span className="pain-text"><strong>Infrastructure complexity</strong> — Terraform, Docker, K8s, CI/CD — the deployment stack is as complex as the app itself. Few people understand it all.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">😨</span>
+            <span className="pain-text"><strong>Deploy fear</strong> — teams deploy infrequently because it's risky. Bigger batches mean bigger failures. The cycle reinforces itself.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">🔧</span>
+            <span className="pain-text"><strong>Config drift</strong> — environment differences between dev, staging, and prod cause "works on my machine" bugs that only appear in production.</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--red)' }}>How Cursor Helps</h3>
+        <div className="solution-card" style={{ borderColor: 'rgba(220, 50, 47, 0.2)', background: 'linear-gradient(135deg, rgba(220, 50, 47, 0.08), rgba(220, 50, 47, 0.02))' }}>
+          <div className="solution-header">
+            <span className="solution-icon">☁️</span>
+            <span className="solution-title" style={{ color: 'var(--red)' }}>AI-Assisted DevOps + MCPs</span>
+          </div>
+          <div className="solution-steps">
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--red)' }}>1</span>
+              <span>Cursor understands infrastructure-as-code (Terraform, Dockerfiles, K8s manifests) and can generate, modify, and debug configs</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--red)' }}>2</span>
+              <span>MCPs connect Cursor to cloud providers and deployment platforms — query status, trigger deploys, read logs without leaving the IDE</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--red)' }}>3</span>
+              <span>When deploys fail, Cursor reads error logs and suggests fixes — closing the loop between "it broke" and "here's the fix"</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="competitor-row">
+          <span className="competitor-label">Tools today</span>
+          <div className="tool-pills">
+            <span className="tool-pill">AWS</span>
+            <span className="tool-pill">Docker</span>
+            <span className="tool-pill">Kubernetes</span>
+            <span className="tool-pill">Terraform</span>
+            <span className="tool-pill">Vercel</span>
+          </div>
+        </div>
+
+        <div className="outcome-callout" style={{ background: 'linear-gradient(135deg, rgba(220, 50, 47, 0.1), rgba(220, 50, 47, 0.03))', borderColor: 'rgba(220, 50, 47, 0.25)' }}>
+          <div className="outcome-label" style={{ color: 'var(--red)' }}>Outcome</div>
+          <div className="outcome-text">
+            Infrastructure stops being a <strong style={{ color: 'var(--red)' }}>black box owned by 2 people</strong> — any engineer can confidently work with deployment configs because AI understands them
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+)
+
+export default SlideDeployDeepDive

--- a/workshop-slides/src/slides/SlideDesignDeepDive.jsx
+++ b/workshop-slides/src/slides/SlideDesignDeepDive.jsx
@@ -1,0 +1,103 @@
+const SlideDesignDeepDive = () => (
+  <>
+    <div className="phase-header">
+      <div className="phase-number design">02</div>
+      <h2>Design</h2>
+    </div>
+    <p className="small" style={{ marginBottom: '0.5rem' }}>
+      How visual design becomes working code — and why the handoff is so painful
+    </p>
+
+    <div className="deepdive-cols">
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--purple)' }}>Discovery Questions</h3>
+        <div className="pain-list">
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"Walk me through how a design goes from Figma to production code today."</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How many rounds of back-and-forth happen between designer and engineer before it looks right?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"Do you have a design system? How well does the implemented code match it?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How do designers give feedback on the built version — screenshots, staging links, Loom videos?"</span>
+          </div>
+        </div>
+
+        <h3 style={{ color: 'var(--red)', marginTop: '0.75rem' }}>Common Pain Points</h3>
+        <div className="pain-list">
+          <div className="pain-item">
+            <span className="pain-icon">🔄</span>
+            <span className="pain-text"><strong>Endless iteration loops</strong> — designer mocks it, engineer builds it, designer says "that's not right," repeat 5-10 times</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">🎨</span>
+            <span className="pain-text"><strong>Lost design intent</strong> — designers think in visual "vibe"; engineers think in divs and CSS. The translation is inherently lossy.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">⏳</span>
+            <span className="pain-text"><strong>Both people blocked</strong> — designer waits for engineer to implement; engineer waits for designer to approve. Two expensive people sitting idle.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">📐</span>
+            <span className="pain-text"><strong>Design system drift</strong> — implemented components slowly diverge from the source-of-truth designs. Nobody catches it until it's a mess.</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--purple)' }}>How Cursor Helps</h3>
+        <div className="solution-card" style={{ borderColor: 'rgba(108, 113, 196, 0.2)', background: 'linear-gradient(135deg, rgba(108, 113, 196, 0.08), rgba(108, 113, 196, 0.02))' }}>
+          <div className="solution-header">
+            <span className="solution-icon">🖼️</span>
+            <span className="solution-title" style={{ color: 'var(--purple)' }}>Design-to-Code via MCPs</span>
+          </div>
+          <div className="solution-steps">
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--purple)' }}>1</span>
+              <span>Designer finalises the mockup in Figma — pixel-perfect, exactly as they envision it</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--purple)' }}>2</span>
+              <span>Cursor uses Figma MCP to read the design and translate it into code that matches the actual codebase's components, tokens, and patterns</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--purple)' }}>3</span>
+              <span>The result is a working implementation — not a throwaway prototype — using real components from the design system</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--purple)' }}>4</span>
+              <span>Engineer reviews and accepts instead of building from scratch. Designer's intent is preserved end-to-end.</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="competitor-row">
+          <span className="competitor-label">Tools today</span>
+          <div className="tool-pills">
+            <span className="tool-pill">Figma</span>
+            <span className="tool-pill">Adobe XD</span>
+            <span className="tool-pill">Sketch</span>
+            <span className="tool-pill">Storybook</span>
+          </div>
+        </div>
+
+        <div className="outcome-callout" style={{ background: 'linear-gradient(135deg, rgba(108, 113, 196, 0.1), rgba(108, 113, 196, 0.03))', borderColor: 'rgba(108, 113, 196, 0.25)' }}>
+          <div className="outcome-label" style={{ color: 'var(--purple)' }}>Outcome</div>
+          <div className="outcome-text">
+            From <strong style={{ color: 'var(--purple)' }}>5-10 rounds of revision</strong> down to <strong style={{ color: 'var(--purple)' }}>review and accept</strong>.
+            The tight AI feedback loop replaces the slow human telephone game.
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+)
+
+export default SlideDesignDeepDive

--- a/workshop-slides/src/slides/SlideDesignVideo.jsx
+++ b/workshop-slides/src/slides/SlideDesignVideo.jsx
@@ -1,0 +1,29 @@
+const SlideDesignVideo = () => (
+  <>
+    <div className="phase-header">
+      <div className="phase-number design">02</div>
+      <h2>Design — In Practice</h2>
+    </div>
+
+    <div className="video-placeholder">
+      <span className="vp-icon">🎬</span>
+      <span className="vp-title">Customer / SE Video: Design-to-Code Pain</span>
+      <span className="vp-desc">
+        Short clip of a designer or engineering lead describing the back-and-forth
+        between design and implementation — and how Figma MCP eliminated the iteration cycle
+      </span>
+    </div>
+
+    <div className="outcome-callout" style={{ marginTop: '1rem', background: 'linear-gradient(135deg, rgba(108, 113, 196, 0.1), rgba(108, 113, 196, 0.03))', borderColor: 'rgba(108, 113, 196, 0.25)' }}>
+      <div className="outcome-label" style={{ color: 'var(--purple)' }}>Key message</div>
+      <div className="outcome-text">
+        Imagine describing a visual design to someone over the phone —
+        that's what the designer-to-engineer handoff feels like today.
+        <strong style={{ color: 'var(--purple)' }}> AI closes that communication gap </strong>
+        by translating pixels directly into code.
+      </div>
+    </div>
+  </>
+)
+
+export default SlideDesignVideo

--- a/workshop-slides/src/slides/SlideDevelopDeepDive.jsx
+++ b/workshop-slides/src/slides/SlideDevelopDeepDive.jsx
@@ -1,0 +1,98 @@
+const SlideDevelopDeepDive = () => (
+  <>
+    <div className="phase-header">
+      <div className="phase-number develop">03</div>
+      <h2>Develop</h2>
+    </div>
+    <p className="small" style={{ marginBottom: '0.5rem' }}>
+      Where the actual code gets written — the core of engineering time and cost
+    </p>
+
+    <div className="deepdive-cols">
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--cursor-blue)' }}>Discovery Questions</h3>
+        <div className="pain-list">
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How long does it take a new engineer to become productive in your codebase?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"What percentage of engineering time is spent writing new code vs. understanding existing code?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How do engineers handle boilerplate, migrations, and repetitive patterns today?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"Do your devs use AI coding tools today? What's working and what's not?"</span>
+          </div>
+        </div>
+
+        <h3 style={{ color: 'var(--red)', marginTop: '0.75rem' }}>Common Pain Points</h3>
+        <div className="pain-list">
+          <div className="pain-item">
+            <span className="pain-icon">🧠</span>
+            <span className="pain-text"><strong>Context switching</strong> — devs spend more time reading and navigating code than writing it. Understanding a large codebase is the real bottleneck.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">🐢</span>
+            <span className="pain-text"><strong>Slow ramp-up</strong> — new hires take months to become productive. Institutional knowledge lives in people's heads, not in tooling.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">🔧</span>
+            <span className="pain-text"><strong>Boilerplate & toil</strong> — repetitive patterns, config files, migrations — engineers spend hours on work that's necessary but not creative.</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--cursor-blue)' }}>How Cursor Helps</h3>
+        <div className="solution-card" style={{ borderColor: 'rgba(38, 139, 210, 0.2)', background: 'linear-gradient(135deg, rgba(38, 139, 210, 0.08), rgba(38, 139, 210, 0.02))' }}>
+          <div className="solution-header">
+            <span className="solution-icon">🚀</span>
+            <span className="solution-title" style={{ color: 'var(--cursor-blue)' }}>AI-Native IDE + Background Agents</span>
+          </div>
+          <div className="solution-steps">
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--cursor-blue)' }}>1</span>
+              <span>Codebase-aware AI understands your entire repo — ask questions, navigate, and get accurate answers grounded in your actual code</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--cursor-blue)' }}>2</span>
+              <span>Agent mode handles multi-file changes end-to-end — describe what you want, Cursor implements across files, runs tests, iterates</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--cursor-blue)' }}>3</span>
+              <span>Background Agents work in parallel — spin up tasks that run asynchronously while you work on other things</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--cursor-blue)' }}>4</span>
+              <span>Rules, context, and MCPs let teams encode their patterns so AI follows company conventions automatically</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="competitor-row">
+          <span className="competitor-label">Tools today</span>
+          <div className="tool-pills">
+            <span className="tool-pill">VS Code</span>
+            <span className="tool-pill">GitHub Copilot</span>
+            <span className="tool-pill">JetBrains</span>
+            <span className="tool-pill">Windsurf</span>
+          </div>
+        </div>
+
+        <div className="outcome-callout">
+          <div className="outcome-label">Outcome</div>
+          <div className="outcome-text">
+            Engineers go from <strong style={{ color: 'var(--cursor-blue)' }}>spending 70% of time reading code</strong> to having an AI pair that already understands the whole codebase — dramatically accelerating both new and experienced developers
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+)
+
+export default SlideDevelopDeepDive

--- a/workshop-slides/src/slides/SlideDevelopVideo.jsx
+++ b/workshop-slides/src/slides/SlideDevelopVideo.jsx
@@ -1,0 +1,27 @@
+const SlideDevelopVideo = () => (
+  <>
+    <div className="phase-header">
+      <div className="phase-number develop">03</div>
+      <h2>Develop — In Practice</h2>
+    </div>
+
+    <div className="video-placeholder">
+      <span className="vp-icon">🎬</span>
+      <span className="vp-title">Customer / SE Video: Development Workflow</span>
+      <span className="vp-desc">
+        Short clip showing a developer using Cursor's Agent mode to implement a feature
+        end-to-end — from understanding the codebase to shipping working code
+      </span>
+    </div>
+
+    <div className="outcome-callout" style={{ marginTop: '1rem' }}>
+      <div className="outcome-label">Key message</div>
+      <div className="outcome-text">
+        The biggest cost isn't writing code — it's <strong style={{ color: 'var(--cursor-blue)' }}>understanding the codebase well enough to change it safely</strong>.
+        Cursor gives every engineer the context of a senior dev who's been on the team for years.
+      </div>
+    </div>
+  </>
+)
+
+export default SlideDevelopVideo

--- a/workshop-slides/src/slides/SlidePlanDeepDive.jsx
+++ b/workshop-slides/src/slides/SlidePlanDeepDive.jsx
@@ -1,0 +1,95 @@
+const SlidePlanDeepDive = () => (
+  <>
+    <div className="phase-header">
+      <div className="phase-number plan">01</div>
+      <h2>Plan</h2>
+    </div>
+    <p className="small" style={{ marginBottom: '0.5rem' }}>
+      How teams go from idea to actionable work — and where it breaks down
+    </p>
+
+    <div className="deepdive-cols">
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--cyan)' }}>Discovery Questions</h3>
+        <div className="pain-list">
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How do you turn a business request into a ticket or spec that an engineer can act on?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How long does it take from 'we want X' to 'an engineer is writing code for X'?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"Who writes specs / PRDs? How much back-and-forth happens before engineering starts?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How often does an engineer start building and realise the spec was unclear or incomplete?"</span>
+          </div>
+        </div>
+
+        <h3 style={{ color: 'var(--red)', marginTop: '0.75rem' }}>Common Pain Points</h3>
+        <div className="pain-list">
+          <div className="pain-item">
+            <span className="pain-icon">🐢</span>
+            <span className="pain-text"><strong>Slow spec handoff</strong> — weeks of meetings, docs, and Slack threads before a single line of code</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">🔄</span>
+            <span className="pain-text"><strong>Ambiguous requirements</strong> — PMs describe intent; engineers need precision. Context is lost in translation.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">📋</span>
+            <span className="pain-text"><strong>Ticket sprawl</strong> — stories/subtasks multiply, dependencies get tangled, nobody has the full picture</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--cyan)' }}>How Cursor Helps</h3>
+        <div className="solution-card">
+          <div className="solution-header">
+            <span className="solution-icon">⚡</span>
+            <span className="solution-title">AI-Assisted Planning</span>
+          </div>
+          <div className="solution-steps">
+            <div className="solution-step">
+              <span className="step-num">1</span>
+              <span>Describe the feature in natural language — Cursor generates a structured PRD with acceptance criteria, edge cases, and implementation notes</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num">2</span>
+              <span>The PRD lives in the repo (markdown), so it evolves with the code — no stale Confluence pages</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num">3</span>
+              <span>Engineers can ask Cursor to break the PRD into tasks, estimate scope, and identify technical risks before writing code</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="competitor-row">
+          <span className="competitor-label">Tools today</span>
+          <div className="tool-pills">
+            <span className="tool-pill">Jira</span>
+            <span className="tool-pill">Linear</span>
+            <span className="tool-pill">Notion</span>
+            <span className="tool-pill">Confluence</span>
+            <span className="tool-pill">GitHub Issues</span>
+          </div>
+        </div>
+
+        <div className="outcome-callout">
+          <div className="outcome-label">Outcome</div>
+          <div className="outcome-text">
+            Go from idea to actionable, code-ready spec in <strong style={{ color: 'var(--cyan)' }}>minutes instead of weeks</strong> — specs stay in sync with reality because they live next to the code
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+)
+
+export default SlidePlanDeepDive

--- a/workshop-slides/src/slides/SlidePlanVideo.jsx
+++ b/workshop-slides/src/slides/SlidePlanVideo.jsx
@@ -1,0 +1,27 @@
+const SlidePlanVideo = () => (
+  <>
+    <div className="phase-header">
+      <div className="phase-number plan">01</div>
+      <h2>Plan — In Practice</h2>
+    </div>
+
+    <div className="video-placeholder">
+      <span className="vp-icon">🎬</span>
+      <span className="vp-title">Customer / SE Video: Planning Pain</span>
+      <span className="vp-desc">
+        Short clip of someone describing the frustration of translating business intent
+        into engineering specs — and how AI-assisted planning changed their workflow
+      </span>
+    </div>
+
+    <div className="outcome-callout" style={{ marginTop: '1rem' }}>
+      <div className="outcome-label">Key message</div>
+      <div className="outcome-text">
+        The bottleneck isn't writing code — it's <strong style={{ color: 'var(--cyan)' }}>figuring out what to build</strong>.
+        Cursor collapses the planning phase by turning intent into structured, code-ready specs.
+      </div>
+    </div>
+  </>
+)
+
+export default SlidePlanVideo

--- a/workshop-slides/src/slides/SlideReviewDeepDive.jsx
+++ b/workshop-slides/src/slides/SlideReviewDeepDive.jsx
@@ -1,0 +1,93 @@
+const SlideReviewDeepDive = () => (
+  <>
+    <div className="phase-header">
+      <div className="phase-number review">05</div>
+      <h2>Review</h2>
+    </div>
+    <p className="small" style={{ marginBottom: '0.5rem' }}>
+      Code review is the quality gate — but it's also the biggest queue in the pipeline
+    </p>
+
+    <div className="deepdive-cols">
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--green)' }}>Discovery Questions</h3>
+        <div className="pain-list">
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How long do PRs sit waiting for review? What's your average time-to-merge?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How many people need to approve a PR before it merges? Is that bottleneck-ing your senior engineers?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"What kinds of issues do code reviews actually catch? Style nits, logic bugs, security gaps?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"Do you have review standards or checklists, or is it ad-hoc?"</span>
+          </div>
+        </div>
+
+        <h3 style={{ color: 'var(--red)', marginTop: '0.75rem' }}>Common Pain Points</h3>
+        <div className="pain-list">
+          <div className="pain-item">
+            <span className="pain-icon">⏳</span>
+            <span className="pain-text"><strong>Review bottleneck</strong> — PRs sit for days waiting for a senior engineer who's already overloaded. It's the #1 source of development delay.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">🔍</span>
+            <span className="pain-text"><strong>Shallow reviews</strong> — reviewers skim large diffs and rubber-stamp. Real bugs slip through because nobody has time to deeply read 500-line PRs.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">🎨</span>
+            <span className="pain-text"><strong>Bikeshedding</strong> — reviews devolve into style debates instead of catching real issues. Wastes everyone's time and energy.</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--green)' }}>How Cursor Helps</h3>
+        <div className="solution-card" style={{ borderColor: 'rgba(133, 153, 0, 0.2)', background: 'linear-gradient(135deg, rgba(133, 153, 0, 0.08), rgba(133, 153, 0, 0.02))' }}>
+          <div className="solution-header">
+            <span className="solution-icon">🤖</span>
+            <span className="solution-title" style={{ color: 'var(--green)' }}>Bugbot + AI-Assisted Review</span>
+          </div>
+          <div className="solution-steps">
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--green)' }}>1</span>
+              <span>Bugbot automatically reviews every PR — catches bugs, security issues, and logic errors that humans miss during quick scans</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--green)' }}>2</span>
+              <span>AI-generated PR descriptions and summaries help reviewers understand changes without reading every line</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--green)' }}>3</span>
+              <span>Style and convention issues are caught by rules and linting, not by humans in review — freeing reviewers to focus on logic and architecture</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="competitor-row">
+          <span className="competitor-label">Tools today</span>
+          <div className="tool-pills">
+            <span className="tool-pill">GitHub PRs</span>
+            <span className="tool-pill">CodeRabbit</span>
+            <span className="tool-pill">SonarQube</span>
+          </div>
+        </div>
+
+        <div className="outcome-callout" style={{ background: 'linear-gradient(135deg, rgba(133, 153, 0, 0.1), rgba(133, 153, 0, 0.03))', borderColor: 'rgba(133, 153, 0, 0.25)' }}>
+          <div className="outcome-label" style={{ color: 'var(--green)' }}>Outcome</div>
+          <div className="outcome-text">
+            Senior engineers spend <strong style={{ color: 'var(--green)' }}>less time reviewing</strong> while code quality <strong style={{ color: 'var(--green)' }}>goes up</strong> — AI handles the tedious checks so humans focus on what matters
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+)
+
+export default SlideReviewDeepDive

--- a/workshop-slides/src/slides/SlideTestDeepDive.jsx
+++ b/workshop-slides/src/slides/SlideTestDeepDive.jsx
@@ -1,0 +1,94 @@
+const SlideTestDeepDive = () => (
+  <>
+    <div className="phase-header">
+      <div className="phase-number test">04</div>
+      <h2>Test</h2>
+    </div>
+    <p className="small" style={{ marginBottom: '0.5rem' }}>
+      Catching bugs before they ship — and why test coverage stays low despite good intentions
+    </p>
+
+    <div className="deepdive-cols">
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--orange)' }}>Discovery Questions</h3>
+        <div className="pain-list">
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"What's your current test coverage? Are you happy with it?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"Who writes tests — the same engineer who wrote the feature, or a QA team?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How often do bugs make it to production that tests should have caught?"</span>
+          </div>
+          <div className="discovery-card">
+            <span className="dq-icon">💬</span>
+            <span className="dq-text">"How long does your CI pipeline take to run? Does it slow down shipping?"</span>
+          </div>
+        </div>
+
+        <h3 style={{ color: 'var(--red)', marginTop: '0.75rem' }}>Common Pain Points</h3>
+        <div className="pain-list">
+          <div className="pain-item">
+            <span className="pain-icon">📉</span>
+            <span className="pain-text"><strong>Low test coverage</strong> — writing tests is tedious, so it gets skipped under deadline pressure. Coverage stays at 20-40%.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">🧪</span>
+            <span className="pain-text"><strong>Tests that don't test the right things</strong> — brittle tests that break on refactors but miss real bugs. High maintenance, low value.</span>
+          </div>
+          <div className="pain-item">
+            <span className="pain-icon">⏱️</span>
+            <span className="pain-text"><strong>Slow CI feedback</strong> — 30-60 min pipelines mean devs context-switch away and come back to failures they've already forgotten.</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="deepdive-col">
+        <h3 style={{ color: 'var(--orange)' }}>How Cursor Helps</h3>
+        <div className="solution-card" style={{ borderColor: 'rgba(203, 75, 22, 0.2)', background: 'linear-gradient(135deg, rgba(203, 75, 22, 0.08), rgba(203, 75, 22, 0.02))' }}>
+          <div className="solution-header">
+            <span className="solution-icon">🧪</span>
+            <span className="solution-title" style={{ color: 'var(--orange)' }}>AI-Generated Tests + Inline Fixing</span>
+          </div>
+          <div className="solution-steps">
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--orange)' }}>1</span>
+              <span>Cursor generates meaningful tests alongside feature code — unit, integration, and edge-case tests based on actual implementation</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--orange)' }}>2</span>
+              <span>When tests fail, Cursor reads the failure output and fixes the code or the test — right in the IDE, no context-switching</span>
+            </div>
+            <div className="solution-step">
+              <span className="step-num" style={{ background: 'var(--orange)' }}>3</span>
+              <span>Background Agents can be tasked with improving test coverage across an entire module while you work on other things</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="competitor-row">
+          <span className="competitor-label">Tools today</span>
+          <div className="tool-pills">
+            <span className="tool-pill">GitHub Actions</span>
+            <span className="tool-pill">Jenkins</span>
+            <span className="tool-pill">CircleCI</span>
+            <span className="tool-pill">Selenium</span>
+          </div>
+        </div>
+
+        <div className="outcome-callout" style={{ background: 'linear-gradient(135deg, rgba(203, 75, 22, 0.1), rgba(203, 75, 22, 0.03))', borderColor: 'rgba(203, 75, 22, 0.25)' }}>
+          <div className="outcome-label" style={{ color: 'var(--orange)' }}>Outcome</div>
+          <div className="outcome-text">
+            Testing goes from <strong style={{ color: 'var(--orange)' }}>a chore that gets skipped</strong> to something that happens automatically with every feature — coverage goes up without slowing teams down
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+)
+
+export default SlideTestDeepDive

--- a/workshop-slides/src/slides/index.js
+++ b/workshop-slides/src/slides/index.js
@@ -2,6 +2,15 @@ import Slide01Title from './Slide01Title.jsx'
 import Slide02Purpose from './Slide02Purpose.jsx'
 import Slide03Agenda from './Slide03Agenda.jsx'
 import Slide04SdlcOverview from './Slide04SdlcOverview.jsx'
+import SlidePlanDeepDive from './SlidePlanDeepDive.jsx'
+import SlidePlanVideo from './SlidePlanVideo.jsx'
+import SlideDesignDeepDive from './SlideDesignDeepDive.jsx'
+import SlideDesignVideo from './SlideDesignVideo.jsx'
+import SlideDevelopDeepDive from './SlideDevelopDeepDive.jsx'
+import SlideDevelopVideo from './SlideDevelopVideo.jsx'
+import SlideTestDeepDive from './SlideTestDeepDive.jsx'
+import SlideReviewDeepDive from './SlideReviewDeepDive.jsx'
+import SlideDeployDeepDive from './SlideDeployDeepDive.jsx'
 import Slide05PreWork from './Slide05PreWork.jsx'
 import SlideGitWorkflowDiagram from './SlideGitWorkflowDiagram.jsx'
 import Slide06Section1Intro from './Slide06Section1Intro.jsx'
@@ -32,6 +41,28 @@ export const slides = [
   { id: 2, component: Slide02Purpose },
   { id: 3, component: Slide03Agenda },
   { id: 4, component: Slide04SdlcOverview },
+
+  // SDLC deep-dive: Plan
+  { id: 4.1, component: SlidePlanDeepDive },
+  { id: 4.11, component: SlidePlanVideo },
+
+  // SDLC deep-dive: Design
+  { id: 4.2, component: SlideDesignDeepDive },
+  { id: 4.21, component: SlideDesignVideo },
+
+  // SDLC deep-dive: Develop
+  { id: 4.3, component: SlideDevelopDeepDive },
+  { id: 4.31, component: SlideDevelopVideo },
+
+  // SDLC deep-dive: Test
+  { id: 4.4, component: SlideTestDeepDive },
+
+  // SDLC deep-dive: Review
+  { id: 4.5, component: SlideReviewDeepDive },
+
+  // SDLC deep-dive: Deploy
+  { id: 4.6, component: SlideDeployDeepDive },
+
   { id: 5, component: SlideGitWorkflowDiagram },
   { id: 5.5, component: Slide05PreWork },
   { id: 6, component: Slide06Section1Intro },

--- a/workshop-slides/src/styles/slides.css
+++ b/workshop-slides/src/styles/slides.css
@@ -1402,3 +1402,302 @@ h3 {
   );
   border-color: rgba(108, 113, 196, 0.3);
 }
+
+/* ─── Deep-dive section slides ─── */
+
+/* Phase header with number pill */
+.phase-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.phase-number {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: white;
+  background: var(--cursor-blue);
+  flex-shrink: 0;
+}
+
+.phase-number.plan { background: var(--cyan); }
+.phase-number.design { background: var(--purple); }
+.phase-number.develop { background: var(--cursor-blue); }
+.phase-number.test { background: var(--orange); }
+.phase-number.review { background: var(--green); }
+.phase-number.deploy { background: var(--red); }
+
+/* Discovery question cards */
+.discovery-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.discovery-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+}
+
+.discovery-card .dq-icon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.discovery-card .dq-text {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+  font-style: italic;
+}
+
+/* Pain point list */
+.pain-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.pain-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.6rem 0.85rem;
+  background: linear-gradient(135deg, rgba(220, 50, 47, 0.06), rgba(220, 50, 47, 0.02));
+  border: 1px solid rgba(220, 50, 47, 0.15);
+  border-radius: 8px;
+  border-left: 3px solid var(--red);
+}
+
+.pain-item .pain-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+}
+
+.pain-item .pain-text {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+.pain-item .pain-text strong {
+  color: var(--red);
+}
+
+/* Solution cards */
+.solution-block {
+  margin-top: 0.5rem;
+}
+
+.solution-card {
+  background: linear-gradient(135deg, rgba(42, 161, 152, 0.08), rgba(42, 161, 152, 0.02));
+  border: 1px solid rgba(42, 161, 152, 0.2);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  margin-top: 0.5rem;
+}
+
+.solution-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.solution-header .solution-icon {
+  font-size: 1.2rem;
+}
+
+.solution-header .solution-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--cyan);
+}
+
+.solution-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.solution-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+.solution-step .step-num {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--cyan);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+/* Competitor tools row */
+.competitor-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+  padding: 0.6rem 1rem;
+  background: var(--card-bg);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+}
+
+.competitor-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.competitor-row .tool-pills {
+  margin-top: 0;
+}
+
+/* Video placeholder */
+.video-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(101, 123, 131, 0.06), rgba(101, 123, 131, 0.02));
+  border: 2px dashed var(--border-strong);
+  border-radius: 12px;
+  padding: 2rem;
+  margin-top: 0.75rem;
+  min-height: 200px;
+  text-align: center;
+  gap: 0.5rem;
+}
+
+.video-placeholder .vp-icon {
+  font-size: 2.5rem;
+  opacity: 0.4;
+}
+
+.video-placeholder .vp-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.video-placeholder .vp-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  max-width: 400px;
+  line-height: 1.5;
+}
+
+/* Outcome callout */
+.outcome-callout {
+  background: linear-gradient(135deg, rgba(38, 139, 210, 0.1), rgba(38, 139, 210, 0.03));
+  border: 1px solid rgba(38, 139, 210, 0.25);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  margin-top: 0.75rem;
+  text-align: center;
+}
+
+.outcome-callout .outcome-label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--cursor-blue);
+  margin-bottom: 0.25rem;
+}
+
+.outcome-callout .outcome-text {
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* Placeholder badge */
+.placeholder-badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 100px;
+  font-size: 0.55rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  background: rgba(181, 137, 0, 0.15);
+  color: var(--yellow);
+  border: 1px solid rgba(181, 137, 0, 0.3);
+  margin-left: 0.5rem;
+}
+
+/* Deep-dive two-col for discovery+pain / solution layout */
+.deepdive-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  align-items: start;
+  margin-top: 0.5rem;
+}
+
+.deepdive-col h3 {
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+/* Section divider slide */
+.section-divider {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 0.75rem;
+}
+
+.section-divider .divider-number {
+  font-size: 4rem;
+  font-weight: 800;
+  opacity: 0.12;
+  line-height: 1;
+}
+
+.section-divider h2 {
+  font-size: 2.5rem;
+  margin-bottom: 0;
+}
+
+.section-divider .divider-subtitle {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  line-height: 1.6;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a full set of deep-dive slides that are inserted **between the SDLC overview page and the existing workshop exercises**. These slides lay the groundwork for non-technical audiences (e.g. salespeople) by walking through each SDLC phase with a consistent structure:

1. **Discovery Questions** — what to ask in discovery to uncover how the prospect handles this phase today
2. **Common Pain Points** — the problems those questions are most likely to surface
3. **How Cursor Helps** — the solution layer: what Cursor does and how the platform technically achieves it
4. **Competitor Tools** — tools currently filling the niche (the "tools today" row)
5. **Outcome Callout** — the key value proposition / ROI summary
6. **Video Placeholder** (Plan, Design, Develop) — dashed-border placeholder for a customer/SE video clip

### Slides added

| Phase | Slide | Content |
|-------|-------|---------|
| **Plan** (01) | `SlidePlanDeepDive` | Full: spec handoff pain, AI-assisted PRD generation |
| **Plan** (01) | `SlidePlanVideo` | Video placeholder + key message |
| **Design** (02) | `SlideDesignDeepDive` | Full: designer-engineer iteration loops, Figma MCP design-to-code |
| **Design** (02) | `SlideDesignVideo` | Video placeholder + key message |
| **Develop** (03) | `SlideDevelopDeepDive` | Full: codebase understanding, Agent mode, Background Agents |
| **Develop** (03) | `SlideDevelopVideo` | Video placeholder + key message |
| **Test** (04) | `SlideTestDeepDive` | Full: low coverage pain, AI-generated tests |
| **Review** (05) | `SlideReviewDeepDive` | Full: review bottleneck, Bugbot |
| **Deploy** (06) | `SlideDeployDeepDive` | Full: infra complexity, AI-assisted DevOps |

### CSS additions

New styles for: `.phase-header`, `.discovery-grid`, `.discovery-card`, `.pain-list`, `.pain-item`, `.solution-card`, `.solution-steps`, `.competitor-row`, `.video-placeholder`, `.outcome-callout`, `.deepdive-cols`, and color variants per phase.

### Architecture / flow

The slides follow the feedback pattern:
- **WHAT** (high-level pain the audience can relate to) → **HOW** (Cursor platform specifics)
- Each phase is self-contained — presenters can skip phases that aren't relevant to a particular prospect
- Video placeholder slides are included for Plan, Design, and Develop; additional video slots can be added for Test/Review/Deploy as content becomes available

### Build

Verified clean build with `vite build` — 0 errors, 0 warnings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e813467-05c5-43ee-a1f8-4e6516bf174e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e813467-05c5-43ee-a1f8-4e6516bf174e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

