### PR TITLE
Double points for orange enemies in Galaga

### DIFF
--- a/projects/renevelasco-cursor/base_mvp/js/score.js
+++ b/projects/renevelasco-cursor/base_mvp/js/score.js
@@ -8,8 +8,11 @@ const Score = (function () {
     current = 0;
   }
 
+  const DOUBLE_POINTS_ROW = 1; // orange (#f84)
+
   function addKill(enemyRow) {
-    const points = ROW_POINTS[enemyRow] || 20;
+    let points = ROW_POINTS[enemyRow] || 20;
+    if (enemyRow === DOUBLE_POINTS_ROW) points *= 2;
     current += points;
     if (current > best) {
       best = current;


### PR DESCRIPTION
## Summary
- Orange enemies (row 1, `#f84`) now award **double points** (160 instead of 80)
- Makes them higher-value targets worth prioritizing during gameplay
- Only touches scoring logic in `score.js` — no other gameplay changes

## Test plan
- [ ] Start the game and destroy an orange (2nd row) enemy
- [ ] Confirm score increases by 160 instead of 80
- [ ] Confirm all other enemy rows still award their normal points (red=100, yellow=60, cyan=40, blue=20)

cc @renevelasco-cursor — please review!

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated change to scoring calculation in `Score.addKill`, with no persistence or gameplay logic changes beyond awarding extra points for one enemy row.
> 
> **Overview**
> Updates scoring so kills in the orange enemy row (`enemyRow === 1`) award **double points** by introducing `DOUBLE_POINTS_ROW` and multiplying the base row score in `Score.addKill`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 324fde39018f23bd2c41ced02b48943dc3c831a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->